### PR TITLE
Basic logic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.res linguist-language=ReScript
+*.resi linguist-language=ReScript

--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
 # ReUrl
+
+ReUrl is a port of the [elm-url](https://github.com/elm/url) library, a powerful Url parser and builder.
+
+## Simple example
+
+```rescript
+
+// We can define our Route module
+module Route = {
+  open UrlParser
+
+  // It will contain an exhaustive list of possible routes, with arguments
+  // Notice that we use `deriving(accessors)` for conveniency, but you don't have to
+  @deriving(accessors)
+  type t = Home | Blog(int) | Something(string, int) | NotFound
+
+  // We can now define our 3 possible paths
+  let topRoute = top->map(home)
+
+  let blogRoute = s("blog")->slash(int())->map(blog)
+
+  // Even complex routes are still easy to read:
+  // something / a string / else / an int
+  let somethingRoute = s("something")->slash(str())->slash(s("else"))->slash(int())->map(something)
+
+  // This function will take a string and try to decode/parse it using one of the provided parsers
+  // If no paths match, then the fallback value will be returned
+  let fromString = oneOf([topRoute, blogRoute, somethingRoute])->parseString(~fallback=notFound)
+}
+
+// You might use some existing library like the bs-webapi
+// Any string value would work anyway
+@val @scope(("window", "location"))
+external currentUrl: string = "href"
+
+// The core logic of our router,
+// it can be used to display some components conditionally in React for example
+Js.log(
+  switch Route.fromString(currentUrl) {
+  | Home => "Home page"
+  | Blog(id) => `Blog page with id ${id->Int.toString}`
+  | Something(x, y) => `Found this ${x} and that ${y->Int.toString}`
+  | NotFound => "Page not found"
+  },
+)
+```
+
+The [`test`](test/Url_Test.res) file contains an example for most of the provided functions.
+
+## Known current limitations
+
+- The QueryParser module is not implemented currently
+- Syntaxically, ReScript doesn't allow [yet](https://github.com/rescript-lang/syntax/pull/220) for custom operators. Once it does, we could imagine this syntax to define the `somethingRoute` from above:
+
+```rescript
+let somethingRoute = (s("something") </> str() </> s("else") </> int())->map(something)
+```
+
+- If you define a parser and don't use it, or if you use the parser _outside_ the module where the route type `t` is defined, you will encounter one of these errors (using the same Route module as above):
+
+```rescript
+module Route = {
+  let blogRoute = s("blog")->slash(int())
+  // Raises a `The type of this module contains type variables that cannot be generalized`
+  // compile error, and later: `let blogRoute: Url.UrlParser.parser<int => '_weak1, '_weak1>`
+}
+
+// When trying to use the above parser outside the module, while it seems it should solve the weak
+// polymorphism issue, it actually introduces an other error:
+Route.blogRoute->UrlParser.parseString(~fallback=Route.notFound, url)
+// Will raise `The type constructor Route.t would escape its scope` compile error
+```
+
+You can check the OCaml [documentation](https://ocamlverse.github.io/content/weak_type_variables.html) explains the first limitation pretty well.
+
+The limitations can be hard to lift upstream, and should be handled downstream, in your application. _It's worth noticing that these type errors won't happen if you follow the canonical example above._

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "bs-platform": "^8.4.2"
+  },
+  "dependencies": {
+    "native-url": "^0.3.4"
   }
 }

--- a/src/Url.res
+++ b/src/Url.res
@@ -1,1 +1,81 @@
-Js.log("Hello!")
+// TODO: Implement our own parser logic
+module NativeUrl = {
+  type t = {
+    auth: Js.Nullable.t<string>,
+    hash: Js.Nullable.t<string>,
+    host: Js.Nullable.t<string>,
+    hostname: Js.Nullable.t<string>,
+    href: string,
+    path: Js.Nullable.t<string>,
+    pathname: Js.Nullable.t<string>,
+    protocol: Js.Nullable.t<string>,
+    search: Js.Nullable.t<string>,
+    slashes: Js.Nullable.t<bool>,
+    port: Js.Nullable.t<string>,
+    query: Js.Nullable.t<string>,
+  }
+
+  @module("native-url") external parse: string => t = "parse"
+
+  @module("native-url") external format: t => string = "format"
+}
+
+type protocol = [#http | #https]
+
+type t = {
+  protocol: protocol,
+  host: string,
+  port: option<int>,
+  path: string,
+  query: option<string>,
+  fragment: option<string>,
+}
+
+let fromNativeUrl = ({NativeUrl.protocol: protocol, hostname, port, pathname, query, hash}) => {
+  let convert = (protocol, hostname) => {
+    protocol: protocol,
+    host: hostname,
+    port: port->Js.Nullable.toOption->Option.flatMap(Int.fromString),
+    path: pathname->Js.Nullable.toOption->Option.getWithDefault(""),
+    query: query->Js.Nullable.toOption,
+    fragment: hash
+    ->Js.Nullable.toOption
+    ->Option.map(hash => hash->Js.String2.sliceToEnd(~from=1))
+    ->Option.flatMap(fragment => fragment == "" ? None : Some(fragment)),
+  }
+
+  switch (protocol->Js.Nullable.toOption, hostname->Js.Nullable.toOption) {
+  | (Some("http:"), Some(hostname)) => Some(convert(#http, hostname))
+  | (Some("https:"), Some(hostname)) => Some(convert(#https, hostname))
+  | _ => None
+  }
+}
+
+let toNativeUrl = ({protocol, host, port, path, query, fragment}) => {
+  let port = port->Option.map(Int.toString)
+  let portWithColon = port->Option.mapWithDefault("", port => `:${port}`)
+  let search = query->Option.map(query => `?${query}`)
+
+  {
+    NativeUrl.auth: Js.Nullable.null,
+    hash: fragment->Option.map(fragment => `#${fragment}`)->Js.Nullable.fromOption,
+    host: `${host}${portWithColon}`->Js.Nullable.return,
+    hostname: host->Js.Nullable.return,
+    // Lost in the conversion
+    href: "",
+    path: `${path}${search->Option.getWithDefault("")}`->Js.Nullable.return,
+    pathname: path->Js.Nullable.return,
+    protocol: switch protocol {
+    | #http => "http:"
+    | #https => "https:"
+    }->Js.Nullable.return,
+    search: search->Js.Nullable.fromOption,
+    query: query->Js.Nullable.fromOption,
+    slashes: true->Js.Nullable.return,
+    port: port->Js.Nullable.fromOption,
+  }
+}
+
+let toString = url => url->toNativeUrl->NativeUrl.format
+
+let fromString = str => str->NativeUrl.parse->fromNativeUrl

--- a/src/Url.resi
+++ b/src/Url.resi
@@ -1,0 +1,14 @@
+type protocol = [#http | #https]
+
+type t = {
+  protocol: protocol,
+  host: string,
+  port: option<int>,
+  path: string,
+  query: option<string>,
+  fragment: option<string>,
+}
+
+let toString: t => string
+
+let fromString: string => option<t>

--- a/src/UrlBuilder.res
+++ b/src/UrlBuilder.res
@@ -1,0 +1,46 @@
+type queryParameter = QueryParameter(string, string)
+
+type root = [#absolute | #relative | #crossOrigin(string)]
+
+let toQueryPair = (QueryParameter(key, value)) => `${key}=${value}`
+
+let toQuery = queryParameters =>
+  switch queryParameters {
+  | [] => ""
+  | _ => `?${queryParameters->Array.map(toQueryPair)->Js.Array2.joinWith("&")}`
+  }
+
+let relative = (~paths=[], ~queryParameters=[], ()) =>
+  `${paths->Js.Array2.joinWith("/")}${toQuery(queryParameters)}`
+
+let absolute = (~paths=[], ~queryParameters=[], ()) => `/${relative(~paths, ~queryParameters, ())}`
+
+let crossOrigin = (~baseUrl, ~paths=[], ~queryParameters=[], ()) =>
+  `${baseUrl}${absolute(~paths, ~queryParameters, ())}`
+
+let rootToPrePath = root =>
+  switch root {
+  | #absolute => "/"
+  | #relative => ""
+  | #crossOrigin(baseUrl) => `${baseUrl}/`
+  }
+
+let custom = (root, ~paths=[], ~queryParameters=[], ~fragment=?, ()) => {
+  let urlWithoutFragment = `${rootToPrePath(root)}${paths->Js.Array2.joinWith("/")}${toQuery(
+      queryParameters,
+    )}`
+
+  switch fragment {
+  | None => urlWithoutFragment
+  | Some(fragment) => `${urlWithoutFragment}#${fragment}`
+  }
+}
+
+module Query = {
+  let string = (~key, ~value) => QueryParameter(
+    Js.Global.encodeURIComponent(key),
+    Js.Global.encodeURIComponent(value),
+  )
+
+  let int = (~key, ~value) => QueryParameter(Js.Global.encodeURIComponent(key), value->Int.toString)
+}

--- a/src/UrlBuilder.resi
+++ b/src/UrlBuilder.resi
@@ -1,0 +1,30 @@
+type queryParameter
+
+type root = [#absolute | #relative | #crossOrigin(string)]
+
+let toQuery: array<queryParameter> => string
+
+let absolute: (~paths: array<string>=?, ~queryParameters: array<queryParameter>=?, unit) => string
+
+let relative: (~paths: array<string>=?, ~queryParameters: array<queryParameter>=?, unit) => string
+
+let crossOrigin: (
+  ~baseUrl: string,
+  ~paths: array<string>=?,
+  ~queryParameters: array<queryParameter>=?,
+  unit,
+) => string
+
+let custom: (
+  root,
+  ~paths: array<string>=?,
+  ~queryParameters: array<queryParameter>=?,
+  ~fragment: string=?,
+  unit,
+) => string
+
+module Query: {
+  let string: (~key: string, ~value: string) => queryParameter
+
+  let int: (~key: string, ~value: int) => queryParameter
+}

--- a/src/UrlParser.res
+++ b/src/UrlParser.res
@@ -1,0 +1,161 @@
+let flatMapArray = (xs, f) => xs->Array.reduce([], (acc, x) => acc->Array.concat(f(x)))
+
+type state<'a> = {
+  visited: list<string>,
+  unvisited: list<string>,
+  params: Map.String.t<array<string>>,
+  frag: option<string>,
+  value: 'a,
+}
+
+// Primitives
+
+type rec parser<'a, 'b> = Parser(state<'a> => array<state<'b>>)
+
+let custom = (_type: string, fromString) => Parser(
+  ({visited, unvisited, params, frag, value}) =>
+    switch unvisited {
+    | list{} => []
+    | list{next, ...rest} =>
+      switch fromString(next) {
+      | Some(nextValue) => [
+          {
+            visited: list{next, ...visited},
+            unvisited: rest,
+            params: params,
+            frag: frag,
+            value: value(nextValue),
+          },
+        ]
+      | None => []
+      }
+    },
+)
+
+let str = () => custom("STRING", x => Some(x))
+
+let int = () => custom("NUMBER", Int.fromString)
+
+let s = (type a, path): parser<a, a> => Parser(
+  ({visited, unvisited, params, frag, value}) =>
+    switch unvisited {
+    | list{} => []
+    | list{next, ...rest} =>
+      if next == path {
+        [
+          {
+            visited: list{next, ...visited},
+            unvisited: rest,
+            params: params,
+            frag: frag,
+            value: value,
+          },
+        ]
+      } else {
+        []
+      }
+    },
+)
+
+// Path
+
+let slash = (Parser(parseBefore), Parser(parseAfter)) => Parser(
+  state => state->parseBefore->flatMapArray(parseAfter),
+)
+
+let mapState = ({visited, unvisited, params, frag, value}, f) => {
+  visited: visited,
+  unvisited: unvisited,
+  params: params,
+  frag: frag,
+  value: f(value),
+}
+
+let map = (Parser(parseArg), subValue) => Parser(
+  ({visited, unvisited, params, frag, value}) =>
+    {visited: visited, unvisited: unvisited, params: params, frag: frag, value: subValue}
+    ->parseArg
+    ->Array.map(state => state->mapState(value)),
+)
+
+let oneOf = parsers => Parser(state => parsers->flatMapArray((Parser(parser)) => parser(state)))
+
+let top = Parser(state => [state])
+
+// Queries
+
+// TODO: Implement
+// <?>
+let q = ()
+
+// TODO: Implement
+let query = ()
+
+// Fragments
+
+// TODO: Implement
+let fragment = ()
+
+// Run Parsers
+
+let rec removeFinalEmpty = segments =>
+  switch segments {
+  | list{} | list{""} => list{}
+  | list{segment, ...rest} => list{segment, ...removeFinalEmpty(rest)}
+  }
+
+let preparePath = path =>
+  switch path->Js.String2.split("/")->List.fromArray {
+  | list{"", ...segments} => segments->removeFinalEmpty
+  | segments => segments->removeFinalEmpty
+  }
+
+let rec getFirstMatch = states =>
+  switch states {
+  | list{} => None
+  | list{{value, unvisited}, ...rest} =>
+    switch unvisited {
+    | list{} | list{""} => Some(value)
+    | _ => getFirstMatch(rest)
+    }
+  }
+
+let addToParametersHelp = (value, values) =>
+  switch values {
+  | None => Some([value])
+  | Some(values) => Some([value]->Js.Array2.concat(values))
+  }
+
+let addParam = (dict, path) =>
+  switch path->Js.String2.split("=") {
+  | [rawKey, rawValue] =>
+    switch (Js.Global.decodeURIComponent(rawKey), Js.Global.decodeURIComponent(rawValue)) {
+    | exception _ => dict
+    | (key, value) => dict->Map.String.update(key, addToParametersHelp(value))
+    }
+  | _ => dict
+  }
+
+let prepareQuery = query =>
+  switch query {
+  | None => Map.String.empty
+  | Some(query) => query->Js.String2.split("&")->Array.reduce(Map.String.empty, addParam)
+  }
+
+let parse = (Parser(parser), {Url.fragment: fragment, path, query}) =>
+  {
+    visited: list{},
+    unvisited: path->preparePath,
+    params: query->prepareQuery,
+    frag: fragment,
+    value: value => value,
+  }
+  ->parser
+  ->List.fromArray
+  ->getFirstMatch
+
+let parseString = (parser, url, ~fallback) =>
+  switch url->Url.fromString {
+  | None => fallback
+  | Some(url) => parser->parse(url)->Option.getWithDefault(fallback)
+  }

--- a/src/UrlParser.resi
+++ b/src/UrlParser.resi
@@ -1,0 +1,38 @@
+type rec parser<_, _>
+
+// Primitives
+
+let custom: (string, string => option<'a>) => parser<'a => 'b, 'b>
+
+let str: unit => parser<string => 'a, 'a>
+
+let int: unit => parser<int => 'a, 'a>
+
+let s: string => parser<'a, 'a>
+
+// Path
+
+let slash: (parser<'a, 'b>, parser<'b, 'c>) => parser<'a, 'c>
+
+let map: (parser<'a, 'b>, 'a) => parser<'b => 'c, 'c>
+
+let oneOf: array<parser<'a, 'b>> => parser<'a, 'b>
+
+let top: parser<'a, 'a>
+
+// Queries
+
+// <?>
+let q: unit
+
+let query: unit
+
+// Fragments
+
+let fragment: unit
+
+// Run Parsers
+
+let parse: (parser<'a => 'a, 'a>, Url.t) => option<'a>
+
+let parseString: (parser<'a => 'a, 'b>, string, ~fallback: 'b) => 'b

--- a/test/Url_Test.res
+++ b/test/Url_Test.res
@@ -1,1 +1,117 @@
-include Url
+let url = "https://www.example.com:2002/foo/bar?key=val#some-fragment"
+
+// Url.fromString
+assert (
+  url->Url.fromString ==
+    Some({
+      Url.protocol: #https,
+      host: "www.example.com",
+      port: Some(2002),
+      path: "/foo/bar",
+      query: Some("key=val"),
+      fragment: Some("some-fragment"),
+    })
+)
+
+// Url.toString (idempotency)
+assert (url->Url.fromString->Option.mapWithDefault("", Url.toString) == url)
+
+// UrlBuilder.absolute
+assert (UrlBuilder.absolute() == "/")
+assert (UrlBuilder.absolute(~paths=["packages", "elm", "core"], ()) == "/packages/elm/core")
+assert (UrlBuilder.absolute(~paths=["blog", 42->Int.toString], ()) == "/blog/42")
+assert (
+  UrlBuilder.absolute(
+    ~paths=["products"],
+    ~queryParameters=[
+      UrlBuilder.Query.string(~key="search", ~value="hat"),
+      UrlBuilder.Query.int(~key="page", ~value=2),
+    ],
+    (),
+  ) == "/products?search=hat&page=2"
+)
+
+// UrlBuilder.relative
+assert (UrlBuilder.relative(~paths=[], ()) == "")
+assert (UrlBuilder.relative(~paths=[], ~queryParameters=[], ()) == "")
+assert (UrlBuilder.relative(~paths=["packages", "elm", "core"], ()) == "packages/elm/core")
+assert (UrlBuilder.relative(~paths=["blog", 42->Int.toString], ()) == "blog/42")
+assert (
+  UrlBuilder.relative(
+    ~paths=["products"],
+    ~queryParameters=[
+      UrlBuilder.Query.string(~key="search", ~value="hat"),
+      UrlBuilder.Query.int(~key="page", ~value=2),
+    ],
+    (),
+  ) == "products?search=hat&page=2"
+)
+
+// UrlBuilder.crossOrigin
+assert (
+  UrlBuilder.crossOrigin(
+    ~baseUrl="https://example.com",
+    ~paths=["products"],
+    (),
+  ) == "https://example.com/products"
+)
+assert (UrlBuilder.crossOrigin(~baseUrl="https://example.com", ()) == "https://example.com/")
+assert (
+  UrlBuilder.crossOrigin(
+    ~baseUrl="https://example.com:8042",
+    ~paths=["over", "there"],
+    ~queryParameters=[UrlBuilder.Query.string(~key="name", ~value="ferret")],
+    (),
+  ) == "https://example.com:8042/over/there?name=ferret"
+)
+
+// UrlBuilder.custom
+assert (
+  UrlBuilder.custom(
+    #absolute,
+    ~paths=["packages", "elm", "core", "latest", "String"],
+    ~fragment="length",
+    (),
+  ) == "/packages/elm/core/latest/String#length"
+)
+assert (
+  UrlBuilder.custom(
+    #relative,
+    ~paths=["there"],
+    ~queryParameters=[UrlBuilder.Query.string(~key="name", ~value="ferret")],
+    (),
+  ) == "there?name=ferret"
+)
+assert (
+  UrlBuilder.custom(
+    #crossOrigin("https://example.com:8042"),
+    ~paths=["over", "there"],
+    ~queryParameters=[UrlBuilder.Query.string(~key="name", ~value="ferret")],
+    ~fragment="nose",
+    (),
+  ) == "https://example.com:8042/over/there?name=ferret#nose"
+)
+
+module Route = {
+  open UrlParser
+
+  @deriving(accessors)
+  type t = Home | Blog(int) | Something(string, int) | NotFound
+
+  let topRoute = top->map(home)
+
+  let blogRoute = s("blog")->slash(int())->map(blog)
+
+  let somethingRoute = s("something")->slash(str())->slash(s("else"))->slash(int())->map(something)
+
+  let fromString = oneOf([topRoute, blogRoute, somethingRoute])->parseString(~fallback=notFound)
+}
+
+assert (Route.fromString("/blog/42") == NotFound)
+assert (Route.fromString("https://example.com/") == Home)
+assert (Route.fromString("https://example.com/blog/42") == Blog(42))
+assert (Route.fromString("https://example.com/blog/foo") == NotFound)
+assert (Route.fromString("https://example.com/something/foo/else/12") == Something("foo", 12))
+assert (Route.fromString("https://example.com/something/foo/else/bar") == NotFound)
+
+Js.log("Tests passed")

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,3 +6,15 @@ bs-platform@^8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.4.2.tgz#778dabd1dfb3bc95e0086c58dabae74e4ebdee8a"
   integrity sha512-9q7S4/LLV/a68CweN382NJdCCr/lOSsJR3oQYnmPK98ChfO/AdiA3lYQkQTp6T+U0I5Z5RypUAUprNstwDtMDQ==
+
+native-url@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.4.tgz#29c943172aed86c63cee62c8c04db7f5756661f8"
+  integrity sha512-6iM8R99ze45ivyH8vybJ7X0yekIcPf5GgLV5K0ENCbmRcaRIDoj37BC8iLEmaaBfqqb8enuZ5p0uhY+lVAbAcA==
+  dependencies:
+    querystring "^0.2.0"
+
+querystring@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=


### PR DESCRIPTION
Implements basic of parsing and building Urls (relies on [native-url](https://www.npmjs.com/package/native-url) for now)

- [x] Parse/Stringify url (relies on native-url)
- [x] Implement Url builder
- [x] Implement Url parser
- [x] Rough tests using `assert`
- [ ] Implement Query parser (in a separate PR)

It's an alternative to the pattern matching based route parsing used in Mikketa, but instead of pattern matching, we use parsers 😄 

Here is a basic (and already working) example:

```rescript
@bs.deriving(accessors)
type route = Home | Blog(int) | Something(string, int) | NotFound

let toRoute = {
  open UrlParser

  oneOf([
    top->map(home),
    s("blog")->slash(int())->map(blog), // "string blog / an int"
    s("something")->slash(str())->slash(s("else"))->slash(int())->map(something), // string something / a string / string else / an int
  ])->parseString(~fallback=notFound)
}

assert ("/blog/42"->toRoute == NotFound)
assert ("https://example.com/"->toRoute == Home)
assert ("https://example.com/blog/42"->toRoute == Blog(42))
assert ("https://example.com/blog/foo"->toRoute == NotFound)
assert ("https://example.com/something/foo/else/12"->toRoute == Something("foo", 12))
assert ("https://example.com/something/foo/else/bar"->toRoute == NotFound)
```

Notice that since operators are [back](https://github.com/rescript-lang/syntax/pull/220), we might be able to go for this kind of syntax when defining the route:

```rescript
let toRoute = {
  open UrlParser

  oneOf([
    home      <$> top,
    blog      <$> s("blog") </> int(),
    something <$> s("something") </> str() </> s("else") </> int(),
  ])->parseString(~fallback=notFound)
}
```

Which is pretty clean and readable 😄 

Also, one of the benefits of this approach comes when handling query params. With the pattern matching approach there is no way to pattern match a `Js.Dict.t`, but here, we can 😄 

_This logic is not implemented yet, and the syntax not decided_

```rescript
let toRoute = {
  open UrlParser

  oneOf([
    home      <$> top,
    something <$> s("something") </> str() <?> Query.int "else"
  ])->parseString(~fallback=notFound)
}

assert ("https://example.com/something/foo?else=12"->toRoute == Something("foo", 12))
```

So no more complex decode/encode logic 👍 